### PR TITLE
Make Jolokia 2 register an actuator endpoint

### DIFF
--- a/sba-server/pom.xml
+++ b/sba-server/pom.xml
@@ -18,6 +18,7 @@
 		<java.version>17</java.version>
 <!--		<spring-boot-admin.version>2.7.4</spring-boot-admin.version>-->
 		<spring-boot-admin.version>3.1.5</spring-boot-admin.version>
+		<jolokia.version>2.0.0-M4</jolokia.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -29,6 +30,27 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<!-- Jolokia 2.X -->
+		<dependency>
+			<groupId>org.jolokia</groupId>
+			<artifactId>jolokia-server-core</artifactId>
+			<version>${jolokia.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jolokia</groupId>
+			<artifactId>jolokia-service-jmx</artifactId>
+			<version>${jolokia.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.jolokia</groupId>
+			<artifactId>jolokia-service-serializer</artifactId>
+			<version>${jolokia.version}</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/sba-server/src/main/java/com/ps/example/sbaserver/JolokiaConfiguration.java
+++ b/sba-server/src/main/java/com/ps/example/sbaserver/JolokiaConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ps.example.sbaserver;
+
+import java.util.function.Supplier;
+
+import org.jolokia.server.core.http.AgentServlet;
+import org.springframework.boot.actuate.endpoint.web.EndpointServlet;
+import org.springframework.boot.actuate.endpoint.web.annotation.ServletEndpoint;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+
+@ServletEndpoint(id = "jolokia")
+@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+public class JolokiaConfiguration implements Supplier<EndpointServlet> {
+
+    @Override
+    public EndpointServlet get() {
+        return new EndpointServlet(new AgentServlet());
+    }
+
+}

--- a/sba-server/src/main/java/com/ps/example/sbaserver/SbaServerApplication.java
+++ b/sba-server/src/main/java/com/ps/example/sbaserver/SbaServerApplication.java
@@ -3,9 +3,11 @@ package com.ps.example.sbaserver;
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
 
 @EnableAdminServer
 @SpringBootApplication
+@Import(JolokiaConfiguration.class)
 public class SbaServerApplication {
 
 	public static void main(String[] args) {

--- a/sba-server/src/main/resources/application.properties
+++ b/sba-server/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 server.port=8081
 management.endpoint.env.show-values=ALWAYS
+management.endpoints.web.exposure.include = jolokia


### PR DESCRIPTION
With this change, I was able to access Jolokia 2 in Spring Boot application:
```
$ curl -s http://localhost:8081/actuator/jolokia | jq .
{
  "request": {
    "type": "version"
  },
  "value": {
    "agent": "2.0.0-M4",
    "protocol": "7.2",
    "details": {
      "agent_version": "2.0.0-M4",
      "agent_id": "192.168.0.221-110725-268e0c1d-servlet",
      "secured": false,
      "url": "http://192.168.0.221:8081/actuator/jolokia"
    },
    "id": "192.168.0.221-110725-268e0c1d-servlet",
    "config": {
      "agentId": "192.168.0.221-110725-268e0c1d-servlet"
    },
    "info": {
      "jmx": {}
    }
  },
  "status": 200
}

$ curl -s http://localhost:8081/actuator/jolokia/read/java.lang:type=Runtime/Name | jq -r .value
110725@everfree.forest
```

I hope this helps. At some point we'll create a PR for Spring Boot itself to bring back `org.springframework.boot.actuate.autoconfigure.jolokia.JolokiaEndpointAutoConfiguration`.